### PR TITLE
feat: Add dark and light mode toggle

### DIFF
--- a/packages/frontend-main/package.json
+++ b/packages/frontend-main/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "@tailwindcss/vite": "^4.1.4",
+        "@vueuse/core": "^13.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-vue-next": "^0.507.0",

--- a/packages/frontend-main/src/App.vue
+++ b/packages/frontend-main/src/App.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import ToggleThemeButton from './components/ui/ToggleThemeButton.vue';
+
 import { Button } from '@/components/ui/button';
+
 </script>
 
 <template>
@@ -27,6 +30,7 @@ import { Button } from '@/components/ui/button';
       <!-- TODO: Make right menu -->
       <!-- This should probably stick -->
       <div class="flex flex-col w-[380px] p-6 h-full">
+        <ToggleThemeButton/>
         <input placeholder="search" class="bg-neutral-200 p-2 w-full" />
       </div>
     </div>

--- a/packages/frontend-main/src/components/ui/ToggleThemeButton.vue
+++ b/packages/frontend-main/src/components/ui/ToggleThemeButton.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { useColorMode } from '@vueuse/core';
+import { Moon, Sun } from 'lucide-vue-next';
+
+import { Button } from '@/components/ui/button';
+
+const mode = useColorMode();
+</script>
+
+<template>
+  <Button @click="mode = mode === 'dark' ? 'light' : 'dark'" class="size-10">
+    <component :is="mode === 'dark' ? Moon : Sun" class="size-5" />
+  </Button>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
     dependencies:
       '@atomone/chronostate':
         specifier: ^2.2.1
-        version: 2.2.1
+        version: 2.2.2
       '@elysiajs/cors':
         specifier: ^1.2.0
         version: 1.2.0(elysia@1.2.25(@sinclair/typebox@0.34.33)(openapi-types@12.1.3)(typescript@5.8.3))
@@ -190,6 +190,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.4(vite@6.3.3(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3))
+      '@vueuse/core':
+        specifier: ^13.1.0
+        version: 13.1.0(vue@3.5.13(typescript@5.7.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -410,9 +413,6 @@ importers:
         version: 5.8.3
 
 packages:
-
-  '@atomone/chronostate@2.2.1':
-    resolution: {integrity: sha512-0HeE8SFEyvouHRSXsJdyuQQFcIpz/80o6DH8pSy4YTgYNGvb5W6+s7McCc19g/Zn5iPAslRSJsuSo1DjqJWhww==}
 
   '@atomone/chronostate@2.2.2':
     resolution: {integrity: sha512-7/1HlTahEwILdg4j7Vs4rMinDZjjpxadr4BWVO63y2Z+MOWHj33l3H+seP0//T8B3UJJ0W8rT9SWcht4lwx6mA==}
@@ -1413,11 +1413,24 @@ packages:
   '@vueuse/core@12.8.2':
     resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
 
+  '@vueuse/core@13.1.0':
+    resolution: {integrity: sha512-PAauvdRXZvTWXtGLg8cPUFjiZEddTqmogdwYpnn60t08AA5a8Q4hZokBnpTOnVNqySlFlTcRYIC8OqreV4hv3Q==}
+    peerDependencies:
+      vue: ^3.5.0
+
   '@vueuse/metadata@12.8.2':
     resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
 
+  '@vueuse/metadata@13.1.0':
+    resolution: {integrity: sha512-+TDd7/a78jale5YbHX9KHW3cEDav1lz1JptwDvep2zSG8XjCsVE+9mHIzjTOaPbHUAk5XiE4jXLz51/tS+aKQw==}
+
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
+  '@vueuse/shared@13.1.0':
+    resolution: {integrity: sha512-IVS/qRRjhPTZ6C2/AM3jieqXACGwFZwWTdw5sNTSKk2m/ZpkuuN+ri+WCVUP8TqaKwJYt/KuMwmXspMAw8E6ew==}
+    peerDependencies:
+      vue: ^3.5.0
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2954,8 +2967,6 @@ packages:
 
 snapshots:
 
-  '@atomone/chronostate@2.2.1': {}
-
   '@atomone/chronostate@2.2.2': {}
 
   '@atomone/event-consumer@1.0.2':
@@ -3817,13 +3828,26 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vueuse/core@13.1.0(vue@3.5.13(typescript@5.7.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 13.1.0
+      '@vueuse/shared': 13.1.0(vue@3.5.13(typescript@5.7.3))
+      vue: 3.5.13(typescript@5.7.3)
+
   '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/metadata@13.1.0': {}
 
   '@vueuse/shared@12.8.2(typescript@5.7.3)':
     dependencies:
       vue: 3.5.13(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
+
+  '@vueuse/shared@13.1.0(vue@3.5.13(typescript@5.7.3))':
+    dependencies:
+      vue: 3.5.13(typescript@5.7.3)
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
I did it as simple as possible, following this approach: https://www.shadcn-vue.com/docs/dark-mode/vite.html

Just let vue-shadcn and tailwind do the job automatically :)
The `theme` is stored in `localStorage` and recovered from it (`vueuse-color-scheme`)
If you want to override dark mode elements, use `class='dark:some-stuff'`

I've  added a [toggle button ](https://github.com/allinbits/dither-service/pull/37/files#diff-07bd1a88dff7e811d3a3bf4a9c1c534c238bccfd4b6e77bb1fa9774684e38d87)