### PR TITLE
fix(wallet): Use AvatarUsername for connected user

### DIFF
--- a/packages/frontend-main/src/components/wallet/WalletConnect.vue
+++ b/packages/frontend-main/src/components/wallet/WalletConnect.vue
@@ -11,6 +11,7 @@ import { getWalletHelp, useWallet, Wallets } from '@/composables/useWallet';
 import DialogDescription from '../ui/dialog/DialogDescription.vue';
 import DialogTitle from '../ui/dialog/DialogTitle.vue';
 import Icon from '../ui/icon/Icon.vue';
+import UserAvatarUsername from '../users/UserAvatarUsername.vue';
 import UserBalance from '../users/UserBalance.vue';
 
 import ConnectButton from './ConnectButton.vue';
@@ -133,12 +134,7 @@ const isValidAddress = computed(() => {
     <template v-if="connectedState">
       <Popover>
         <PopoverTrigger>
-          <div class="flex flex-row items-center justify-center cursor-pointer">
-            <div class="bg-secondary w-10 h-10 rounded-full mr-3"></div>
-            <div class="flex flex-col justify-around">
-              <div class="text-light text-200">{{ shorten(address) }}</div>
-            </div>
-          </div>
+          <UserAvatarUsername :userAddress="address"/>
         </PopoverTrigger>
         <PopoverContent>
           <div class="flex flex-col gap-4">

--- a/packages/frontend-main/src/layouts/panels/LeftPanel.vue
+++ b/packages/frontend-main/src/layouts/panels/LeftPanel.vue
@@ -50,7 +50,7 @@ const popovers = usePopups();
           </RouterLink>
 
           <RouterLink
-            to="/profile/:address"
+            :to="`/profile/${wallet.address.value}`"
             class="flex flex-row items-center gap-3"
           >
             <div class="flex items-center justify-center h-[52px]">
@@ -62,13 +62,12 @@ const popovers = usePopups();
       </nav>
 
       <Button class="w-[207px] xl:inline hidden" @click="popovers.show('newPost', {})" v-if="wallet.loggedIn.value">New post</Button>
-      <WalletConnect />
 
       <LikePostDialog />
       <DislikePostDialog />
       <NewPostDialog />
     </div>
 
-    <div>Stuff here?</div>
+    <WalletConnect />
   </header>
 </template>


### PR DESCRIPTION
We could place the Connext Wallet button somewhere else, etc. It's just a quick enhancement

![image](https://github.com/user-attachments/assets/e189995d-e515-4fff-a6a5-12b9b133f76e)
