### PR TITLE
fix: add netlify redirect to support sublinks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
 [build]
 publish = "./packages/frontend-main/dist"
 command = "pnpm -F ./packages/frontend-main build"
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
before this, navigating to a sublink (via url or external link) would result in the netlify 404
for example, paste `https://dither-staging.netlify.app/notifications` into your browser url, you will see:
<img width="525" alt="Screenshot 2025-05-21 at 15 17 27" src="https://github.com/user-attachments/assets/ea67cf88-c9d3-4c39-b3c2-548c22e2a6fc" />

after this, we correctly navigate to the page