### PR TITLE
fix: Enable post message text to break

### DIFF
--- a/packages/frontend-main/src/components/posts/PostMessage.vue
+++ b/packages/frontend-main/src/components/posts/PostMessage.vue
@@ -7,7 +7,7 @@ defineProps<{ post: Post }>();
 </script>
 
 <template>
-  <span class="leading-6 text-sm">
+  <span class="leading-6 text-sm break-all">
     {{ post.message }}
   </span>
 </template>


### PR DESCRIPTION
Prevents this:

![image](https://github.com/user-attachments/assets/97b10b63-d72e-413d-875a-86e05bf92af7)
