### PR TITLE
fix: cookie site settings

### DIFF
--- a/packages/api-main/src/posts/auth.ts
+++ b/packages/api-main/src/posts/auth.ts
@@ -14,7 +14,8 @@ export async function Auth(body: typeof Posts.AuthBody.static, auth: Cookie<stri
 
         const result = verifyAndCreate(body.pub_key.value, body.signature, body.id);
         if (result.status === 200) {
-            auth.set({ sameSite: 'strict', httpOnly: false, value: result.bearer, maxAge: 259200 });
+            // TODO - When deployed the samesite should be set to strict for subdomain deployment
+            auth.set({ sameSite: 'lax', httpOnly: true, value: result.bearer, maxAge: 259200, secure: true, path: '/' });
             return { status: 200 };
         }
     }

--- a/packages/frontend-main/src/composables/useWallet.ts
+++ b/packages/frontend-main/src/composables/useWallet.ts
@@ -11,6 +11,7 @@ import chainInfo from '@/chain-config.json';
 import { useWalletDialogStore } from '@/stores/useWalletDialogStore';
 import { useWalletStateStore } from '@/stores/useWalletStateStore';
 
+const apiRoot = import.meta.env.VITE_API_ROOT ?? 'http://localhost:3000';
 const destinationWallet = import.meta.env.VITE_COMMUNITY_WALLET ?? 'atone1uq6zjslvsa29cy6uu75y8txnl52mw06j6fzlep';
 
 export enum Wallets {
@@ -30,6 +31,28 @@ export const getWalletHelp = (wallet: Wallets) => {
             return 'https://guide.cosmostation.io/web_wallet_en.html';
     }
 };
+
+const isCredentialsValid = async () => {
+    const resVerifyRaw = await fetch(apiRoot + '/auth-verify', {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+    });
+
+    if (resVerifyRaw.status !== 200) {
+        return false;
+    }
+
+    const resVerify = await resVerifyRaw.json();
+    if (resVerify.status !== 200) {
+        return false;
+    }
+
+    return true;
+};
+
 const useWalletInstance = () => {
     const walletDialogStore = useWalletDialogStore();
     const walletState = storeToRefs(useWalletStateStore());
@@ -159,7 +182,6 @@ const useWalletInstance = () => {
         }
 
         if (walletState.address.value) {
-            const apiRoot = import.meta.env.VITE_API_ROOT ?? 'http://localhost:3000';
             const headers: Record<string, string> = {
                 'Content-Type': 'application/json',
             };
@@ -167,20 +189,44 @@ const useWalletInstance = () => {
                 address: walletState.address.value,
             };
 
+            if (walletState.isAuthenticated.value) {
+                return;
+            }
+
+            const isValid = await isCredentialsValid();
+            if (isValid) {
+                return;
+            }
+
             try {
+                // Create the authentication request
                 const responseRaw = await fetch(apiRoot + '/auth-create', {
                     body: JSON.stringify(postBody),
                     method: 'POST',
                     headers,
                 });
                 const response = (await responseRaw.json()) as { status: number; id: number; message: string };
+
+                // Sign the authentication request
                 const signedMsg = await signMessage(response.message);
-                await fetch(apiRoot + '/auth', {
+                const resAuthRaw = await fetch(apiRoot + '/auth', {
                     body: JSON.stringify({ ...signedMsg, id: response.id }),
                     method: 'POST',
                     headers,
                     credentials: 'include',
                 });
+
+                if (resAuthRaw.status !== 200) {
+                    walletState.isAuthenticated.value = false;
+                    return;
+                }
+
+                const resAuth = await resAuthRaw.json();
+                if (resAuth.status !== 200) {
+                    walletState.isAuthenticated.value = false;
+                    return;
+                }
+
                 walletState.isAuthenticated.value = true;
             }
             catch (e) {


### PR DESCRIPTION
This modifies the cookie so it uses `lax` since we're doing cross-site requests at the moment.

We'll restore this to `strict` when we go to mainnet and standardize our subdomains.

This also fixes signing with the wallet every single time you connect.