### PR TITLE
fix: checkpoints when there is a queue

### DIFF
--- a/packages/reader-main/src/index.ts
+++ b/packages/reader-main/src/index.ts
@@ -55,7 +55,7 @@ async function handleAction(action: Action) {
 }
 
 async function handleLastBlock(block: string) {
-    if (lastActionProcessed + msCheckpointTime < Date.now()) {
+    if (lastActionProcessed + msCheckpointTime < Date.now() && queue.size() <= 0) {
         lastActionProcessed = Date.now();
         const didUpdate = await updateLastBlock(block);
         if (!didUpdate) {


### PR DESCRIPTION
This ensures that a checkpoint is not created if there is a queue size, it ensures that the stored blocks are not skipping ahead of the queue.