### PR TITLE
feat: added fly.io deployment configs for api and reader

### DIFF
--- a/packages/api-main/.dockerignore
+++ b/packages/api-main/.dockerignore
@@ -1,0 +1,6 @@
+/.git
+/node_modules
+.dockerignore
+.env
+Dockerfile
+fly.toml

--- a/packages/api-main/drizzle.config.ts
+++ b/packages/api-main/drizzle.config.ts
@@ -12,4 +12,5 @@ export default defineConfig({
     dbCredentials: {
         url: process.env.PG_URI!,
     },
+    tablesFilter: ['!pg_*', '!information_schema.*'], // Exclude system tables
 });

--- a/packages/api-main/fly.toml
+++ b/packages/api-main/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml app configuration file generated for dither-testnet-api-main on 2025-06-05T14:14:50-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'dither-testnet-api-main'
+primary_region = 'iad'
+
+[build]
+
+[http_service]
+internal_port = 3000
+force_https = true
+auto_start_machines = true
+min_machines_running = 1
+processes = ['app']
+
+[[vm]]
+size = 'shared-cpu-1x'
+memory = "1gb"
+
+# The following line is used to attach the app to a specific volume.
+# fly mpg attach k1v53olj8gr8q6p9 --variable-name PG_URI

--- a/packages/reader-main/.dockerignore
+++ b/packages/reader-main/.dockerignore
@@ -1,0 +1,5 @@
+# flyctl launch added from .gitignore
+**/node_modules
+**/dist
+**/dist/*
+fly.toml

--- a/packages/reader-main/docker-compose.yml
+++ b/packages/reader-main/docker-compose.yml
@@ -2,12 +2,12 @@ services:
     chronosync:
         build: .
         restart: always
-        container_name: "chronosync"
+        container_name: 'chronosync'
         environment:
             API_URLS: 'https://atomone-api.allinbits.com,https://atomone-rest.publicnode.com'
             START_BLOCK: '2605764'
             BATCH_SIZE: 50
-            MEMO_PREFIX: "dither."
-            RECEIVER: "atone1uq6zjslvsa29cy6uu75y8txnl52mw06j6fzlep"
+            MEMO_PREFIX: 'dither.'
+            RECEIVER: 'atone1uq6zjslvsa29cy6uu75y8txnl52mw06j6fzlep'
             # LOG: process.env.LOG === 'true' ? true : false,
         command: ['pnpm', 'start']

--- a/packages/reader-main/fly.toml
+++ b/packages/reader-main/fly.toml
@@ -1,0 +1,18 @@
+# fly.toml app configuration file generated for dither-testnet-reader-main on 2025-06-05T15:58:33-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'dither-testnet-reader-main'
+primary_region = 'iad'
+
+[build]
+
+[env]
+BATCH_SIZE = "500"
+MEMO_PREFIX = "dither."
+
+[[vm]]
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1


### PR DESCRIPTION
This adds a `testnet` deployment target on fly.io for dither to support running our dither backend. 

Context on the Fly.io deployment. 
- Fly.io is configured with a managed postgres instance that is only routable inside our fly.io org
- `api-main` exposes port 3000 to the public over `:443` with TLS
- `api-main` exposes port 3001 only internally to the fly network
- `reader-main` exposes no ports, but is able to talk to `api-main` and the testnet blockchain

What this includes:
- `fly.toml` for both `reader-main` and `api-main`
- `.dockerignore` to ensure certain files never make it into a docker image
- A small change to the `drizzle.config.ts` file so that db:push is happy with managed postgres on fly.io


What this does not include:
- Instructions on how to use fly.io
- multiple environment support (testnet vs mainnet, though that is easy to add later)
- CI automation for deployments (we can wire that up once we confirm fly.io is happy and we have DNS setup)
- There is _no_ UI setup for this. This is the API backend + postgres config + ChronoSync for testnet.
