### PR TITLE
fix: Set overflow-y to body instead of html

### DIFF
--- a/packages/frontend-main/src/components/ui/dialog/Dialog.vue
+++ b/packages/frontend-main/src/components/ui/dialog/Dialog.vue
@@ -1,36 +1,10 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue';
 import { DialogRoot, type DialogRootEmits, type DialogRootProps, useForwardPropsEmits } from 'reka-ui';
 
 const props = defineProps<DialogRootProps>();
 const emits = defineEmits<DialogRootEmits>();
 
 const forwarded = useForwardPropsEmits(props, emits);
-
-// NOTE: Normally we can just watch props.open
-// but with current usage, we remove the dialog from DOM when not showing
-// so we need to toggle overflow-hidden when component mounts and unmounts
-onMounted(() => {
-    const html = document.documentElement;
-    const body = document.body;
-    if (props.open) {
-        html.classList.add('overflow-hidden');
-        html.classList.add('h-full');
-        body.classList.add('overflow-hidden');
-        body.classList.add('h-full');
-    }
-});
-
-onUnmounted(() => {
-    const html = document.documentElement;
-    const body = document.body;
-    if (props.open) {
-        html.classList.remove('overflow-hidden');
-        html.classList.remove('h-full');
-        body.classList.remove('overflow-hidden');
-        body.classList.remove('h-full');
-    }
-});
 
 </script>
 

--- a/packages/frontend-main/src/style.css
+++ b/packages/frontend-main/src/style.css
@@ -131,11 +131,9 @@
   * {
     @apply border-border outline-ring/50;
   }
-  html {
-    overflow-y: scroll;
-  }
   body {
     @apply bg-background text-foreground;
+    overflow-y: scroll;
     font-family: 'Inter', sans-serif;
     line-height: normal;
   }


### PR DESCRIPTION
Set the `overflow-y` to `body` (More correct way than `html`, fits with `reka-ui`)
https://github.com/allinbits/dither-service/blob/fix/body-scroll/packages/frontend-main/src/style.css#L136

Revert these changes: https://github.com/allinbits/dither-service/pull/146/files, because it's not needed anymore so

