### PR TITLE
fix: Replace old inputs

### DIFF
--- a/packages/frontend-main/src/components/ui/input/Input.vue
+++ b/packages/frontend-main/src/components/ui/input/Input.vue
@@ -26,7 +26,7 @@ const modelValue = useVModel(props, 'modelValue', emits, {
     v-model="modelValue"
     data-slot="input"
     :class="cn(
-      'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+      'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-10 w-full min-w-0 rounded-xs border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
       'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
       'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
       props.class,

--- a/packages/frontend-main/src/components/ui/input/InputPhoton.vue
+++ b/packages/frontend-main/src/components/ui/input/InputPhoton.vue
@@ -4,6 +4,8 @@ import { computed, onMounted, watch } from 'vue';
 import { useBalanceFetcher } from '@/composables/useBalanceFetcher';
 import { useWallet } from '@/composables/useWallet';
 
+import Input from './Input.vue';
+
 import { formatAmount } from '@/utility/text';
 
 const model = defineModel<number>();
@@ -61,15 +63,8 @@ onMounted(() => {
 <template>
   <div class="flex flex-col w-full gap-2">
     <div class="flex flex-row gap-4 items-center w-full">
-      <input
-        class="bg-white inline-flex w-full py-2 appearance-none items-center justify-center px-[10px] text-sm leading-none outline-none dark:text-black border"
-        type="number"
-        v-model="model"
-        autocomplete="off"
-        :step="1"
-        :min="min"
-        :max="max"
-      />
+      <Input v-model="model" :placeholder="$t('placeholders.search')" type="number"         :min="min"
+             :max="max" autocomplete="off"/>
       <span class="dark:text-white">PHOTON</span>
     </div>
     <span class="text-left text-sm" v-if="balance">{{ formatAmount(photonBalanceSubtracted, 6) }} Available</span>

--- a/packages/frontend-main/src/components/ui/search/SearchInput.vue
+++ b/packages/frontend-main/src/components/ui/search/SearchInput.vue
@@ -26,7 +26,7 @@ const gotoExplore = () => {
 <template>
   <div>
     <div class="search-input flex items-center gap-2 relative">
-      <Input @keyup.enter="gotoExplore" class="w-full h-[40px] rounded-xs" v-model="query" :placeholder="$t('placeholders.search')"/>
+      <Input @keyup.enter="gotoExplore" v-model="query" :placeholder="$t('placeholders.search')"/>
 
       <CircleX
         v-if="query"

--- a/packages/frontend-main/src/components/wallet/WalletConnectDialog.vue
+++ b/packages/frontend-main/src/components/wallet/WalletConnectDialog.vue
@@ -11,6 +11,7 @@ import { getWalletHelp, useWallet, Wallets } from '@/composables/useWallet';
 import DialogDescription from '../ui/dialog/DialogDescription.vue';
 import DialogTitle from '../ui/dialog/DialogTitle.vue';
 import Icon from '../ui/icon/Icon.vue';
+import Input from '../ui/input/Input.vue';
 import UserBalance from '../users/UserBalance.vue';
 
 import ConnectButton from './ConnectButton.vue';
@@ -167,9 +168,8 @@ const isValidAddress = computed(() => {
           <div class="flex flex-col text-grey-100 text-200 font-medium text-center leading-5">
             {{ $t('components.WalletConnect.enterAddress') }}
           </div>
-          <input
+          <Input
             v-model="publicAddress"
-            class="flex p-4 items-center self-stretch rounded-lg bg-grey-200 outline-none text-100 leading-4 placeholder-grey-100"
             :placeholder="$t('components.WalletConnect.addressPlaceholder')"
           />
           <div class="flex flex-col gap-4">

--- a/packages/frontend-main/src/views/ExploreView.vue
+++ b/packages/frontend-main/src/views/ExploreView.vue
@@ -26,7 +26,7 @@ query.value = route.query.q as string;
 <template>
   <MainLayout>
     <div class="search-input flex items-center gap-2 relative">
-      <Input class="w-full h-[40px] rounded-md m-4 pr-10" v-model="query" :placeholder="$t('placeholders.search')"/>
+      <Input class="m-4" v-model="query" :placeholder="$t('placeholders.search')"/>
 
       <CircleX
         v-if="query"


### PR DESCRIPTION
Use the shadcn/reka `Input` everywhere instead of `input`
https://github.com/allinbits/dither-service/blob/fix/replace-inputs/packages/frontend-main/src/components/ui/input/Input.vue