### PR TITLE
chore(infra): moving non-secret ENV to fly.toml for better visibility

### DIFF
--- a/packages/reader-main/fly.toml
+++ b/packages/reader-main/fly.toml
@@ -8,9 +8,15 @@ primary_region = 'iad'
 
 [build]
 
+# non-secret environment variables
+# AUTH is also required but is set in the secrets on fly.io
 [env]
 BATCH_SIZE = "500"
 MEMO_PREFIX = "dither."
+START_BLOCK = "2605764"
+RECEIVER = "atone1uq6zjslvsa29cy6uu75y8txnl52mw06j6fzlep"
+API_ROOT = "http://dither-testnet-api-main.internal:3000/v1"
+API_URLS = "https://atomone-api.allinbits.com,https://atomone-rest.publicnode.com"
 
 [[vm]]
 memory = '1gb'


### PR DESCRIPTION
On July 2, 2025, we had a small issue when deploying some important updates, where it wasn't clear what environment variables were being set for the testnet environment. This change moves some ENV that were stored in fly.io secrets that should be stored in the `[env]` section of the `fly.toml` file. This simplifies change management tasks makes it clearer how this environmen is setup. Notably, `AUTH` still exists in fly.io secrets, since that is sensitive data.


NOTE: Once this is approved and merged, I will remove these corresponding secrets from fly.io