### PR TITLE
fix: fix not found when clicking on notif

### DIFF
--- a/packages/api-main/drizzle/schema.ts
+++ b/packages/api-main/drizzle/schema.ts
@@ -125,6 +125,7 @@ export const NotificationTable = pgTable(
     'notifications',
     {
         hash: varchar({ length: 64 }).notNull(),
+        post_hash: varchar({ length: 64 }),
         owner: varchar({ length: 44 }).notNull(),
         actor: varchar({ length: 44 }).notNull(),
         type: notificationTypeEnum().notNull(),

--- a/packages/api-main/src/shared/notify.ts
+++ b/packages/api-main/src/shared/notify.ts
@@ -8,6 +8,7 @@ const statementInsertNotification = getDatabase()
     .values({
         owner: sql.placeholder('owner'),
         hash: sql.placeholder('hash'),
+        post_hash: sql.placeholder('post_hash'),
         type: sql.placeholder('type'),
         timestamp: sql.placeholder('timestamp'),
         subcontext: sql.placeholder('subcontext'),
@@ -52,6 +53,7 @@ export const notify = async (data: {
 
     await statementInsertNotification.execute({
         owner: owner.toLowerCase(),
+        post_hash: data.post_hash?.toLowerCase(),
         hash: data.hash.toLowerCase(),
         type: data.type,
         timestamp: data.timestamp ?? null,

--- a/packages/frontend-main/src/components/notifications/NotificationWrapper.vue
+++ b/packages/frontend-main/src/components/notifications/NotificationWrapper.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { Notification } from 'api-main/types/notifications';
 
+import { computed } from 'vue';
 import { Check } from 'lucide-vue-next';
 
 import { useReadNotification } from '@/composables/useReadNotification';
@@ -15,12 +16,33 @@ import Button from '@/components/ui/button/Button.vue';
 
 const { readNotification } = useReadNotification();
 
-defineProps<{ notification: Notification }>();
+const props = defineProps<{ notification: Notification }>();
+
+const navigationPath = computed(() => {
+    const notification = props.notification;
+
+    // actions on post
+    if (['like', 'dislike', 'flag'].includes(notification.type)) {
+        return `/post/${notification.post_hash}`;
+    }
+
+    // actions on user
+    if (['follow'].includes(notification.type)) {
+        return `/profile/${notification.actor}`;
+    }
+
+    // reply
+    if (['reply'].includes(notification.type)) {
+        return `/post/${notification.hash}`;
+    }
+
+    return '/';
+});
 
 </script>
 
 <template>
-  <RouterLink :to="`/post/${notification.hash}`" custom v-slot="{ navigate }">
+  <RouterLink :to="navigationPath" custom v-slot="{ navigate }">
     <div class="flex flex-row gap-3 border-b cursor-pointer p-4" @click="navigate">
       <RouterLink :to="`/profile/${notification.actor}`">
         <UserAvatar :userAddress="notification.actor" />


### PR DESCRIPTION
fixed #234 

This PR includes fixes on BE and FE sides:
- BE: added post_hash into notif, so we have needed info when needed
- FE: navigate to different link depending on notif type