### PR TITLE
fix: Avoid emptying reply message before creating it

### DIFF
--- a/packages/frontend-main/src/views/PostView.vue
+++ b/packages/frontend-main/src/views/PostView.vue
@@ -60,10 +60,10 @@ async function handleReply() {
     if (!canReply.value || !post.value) {
         return;
     }
-    reply.value = '';
     const toastId = showBroadcastingToast('Reply');
     try {
         await createReply({ parentPost: post, message: reply.value, amountAtomics: amountAtomics.value });
+        reply.value = '';
     }
     finally {
         toast.dismiss(toastId);


### PR DESCRIPTION
Currently, we make empty replies when replying from a post page
<img width="656" height="150" alt="image" src="https://github.com/user-attachments/assets/7b235b8f-6269-48b7-8ffa-b5dbc8c70052" />



My bad...
Fixed