### PR TITLE
fix: Avoid reseting input photon value before action

### DIFF
--- a/packages/frontend-main/src/composables/useTxDialog.ts
+++ b/packages/frontend-main/src/composables/useTxDialog.ts
@@ -23,7 +23,6 @@ export const useTxDialog = <T>(
         popups.state[dialogType] = null;
         txError.value = undefined;
         txSuccess.value = undefined;
-        inputPhotonModel.value = Decimal.fromAtomics('1', fractionalDigits).toFloatApproximation();
     };
 
     watch([wallet.loggedIn, wallet.address], async () => {


### PR DESCRIPTION
Currently, the PHOTON amount will always be 0.000001, whatever the entered amount.
Because it's reseted before making the TX. It's a old behavior that we don't need anymore

<img width="498" height="246" alt="image" src="https://github.com/user-attachments/assets/f231670d-076e-4ebc-a4ef-efa03955c610" />

My bad...
Fixed