### PR TITLE
fix(frontend): broken timeline display in replies screen

### DIFF
--- a/packages/frontend-main/src/components/posts/PostItem.vue
+++ b/packages/frontend-main/src/components/posts/PostItem.vue
@@ -25,8 +25,7 @@ const usedPost = computed(() => cachedPost.value || props.post);
 
 <template>
   <RouterLink v-if="usedPost" :to="`/post/${usedPost.hash}`" custom v-slot="{ navigate }">
-    <div @click="navigate"
-      :class="cn('flex flex-row gap-3 cursor-pointer pb-2 pt-4 pl-4 pr-2 relative hover:bg-accent/30 active:bg-accent/30 transition-colors', !showTimeline && 'border-b')">
+    <div @click="navigate" :class="cn('flex flex-row gap-3 cursor-pointer pb-2 pt-4 pl-4 pr-2 relative hover:bg-accent/30 active:bg-accent/30 transition-colors', !showTimeline && 'border-b')">
       <div :class="cn('w-[40px] h-full flex flex-col items-center absolute', !showTimeline && 'hidden')">
         <div class="w-[3px] bg-border h-full" />
       </div>


### PR DESCRIPTION
Fixed post item layout where the timeline line was overlapping content. Content and metadata now align to the right of the timeline, like other platforms such as X and Bluesky.

Check it out: https://dither.chat/profile/atone16k0xnxqr48qdwxreu6rgcghg0xp9hn7vpn06nm/replies

Before:

<img width="450" src="https://github.com/user-attachments/assets/8fe5920e-c4d6-4077-bfe8-f696d92ca2b8" />

After:

<img width="450" src="https://github.com/user-attachments/assets/66ee49e8-a6e3-4846-9e0a-f485c2dc6789" />
