### PR TITLE
chore: correct image names in Tilt config file

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,15 +1,20 @@
 # -*- mode: Python -*
 
+update_settings(suppress_unused_image_warnings=[
+  "ditherchat-api-main",
+  "ditherchat-reader-main",
+])
+
 docker_compose('docker-compose.yml')
 
-docker_build('ditherchat_api-main', './packages/api-main',
+docker_build('ditherchat-api-main', './packages/api-main',
   live_update = [
     sync('./packages/api-main/src', '/app'),
     run('pnpm install', trigger='package.json'),
     restart_container(),
   ])
 
-docker_build('ditherchat_reader-main', './packages/reader-main',
+docker_build('ditherchat-reader-main', './packages/reader-main',
   live_update = [
     sync('./packages/reader-main/src', '/app'),
     run('pnpm install', trigger='package.json'),


### PR DESCRIPTION
Follow-up to #377 

This fixes an issue with Tilt failing because of Docker image names.
It seems to work fine when using "-" instead of "_" for the image names.

The change in the names triggers a Docker warning for any of these two names, for example:
```
Image not used in any Docker Compose config:
    ✕ ditherchat-reader-main
Did you mean…
    - ditherchat_reader-main
    - ditherchat_api-main
    - postgres
Skipping this image build
If this is deliberate, suppress this warning with: update_settings(suppress_unused_image_warnings=["ditherchat-reader-main"])
Successfully loaded Tiltfile (265.501334ms)
```

So I added the recommended call to Tilt's `update_settings()` to ignore them.