### PR TITLE
chore: lower feed publication rate limiter

### DIFF
--- a/packages/feed-sync/src/feed/publisher.ts
+++ b/packages/feed-sync/src/feed/publisher.ts
@@ -6,7 +6,7 @@ import { Markup, Telegraf } from 'telegraf';
 import logger from '../logger';
 
 // Dither post.
-type Post = Record<string, any>; // TODO: Create a package that defines the post type and deals with TG message send
+export type Post = Record<string, any>; // TODO: Create a package that defines the post type and deals with TG message send
 
 // Publisher defines an interface for Dither message publishers
 export interface Publisher<T = unknown> {
@@ -39,9 +39,10 @@ export class TelegramPublisher implements Publisher<Post> {
     this.chatId = chatId;
     this.bot = new Telegraf(token);
 
-    // Limit to 20 messages per minute, with bursts of 1 message per second.
+    // Limit to 10 messages per minute, with bursts of 1 message per second.
     // https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
-    this.limiter = new RateLimiter({ tokensPerInterval: 20, interval: 'minute' });
+    // API seems to allow 20 per minute but using 15 to be safe.
+    this.limiter = new RateLimiter({ tokensPerInterval: 15, interval: 'minute' });
     this.burst = new RateLimiter({ tokensPerInterval: 1, interval: 'second' });
   }
 

--- a/packages/feed-sync/src/index.ts
+++ b/packages/feed-sync/src/index.ts
@@ -1,6 +1,6 @@
 import type { Query } from 'pg';
 
-import type { Publisher } from './feed/publisher';
+import type { Post, Publisher } from './feed/publisher';
 
 import process from 'node:process';
 
@@ -13,7 +13,7 @@ import logger from './logger';
 
 // Runs a feed replication service.
 export async function main() {
-  let publisher: Publisher;
+  let publisher: Publisher<Post>;
 
   if (config.telegram.token && config.telegram.chatId) {
     publisher = new TelegramPublisher(config.telegram.token, config.telegram.chatId);
@@ -40,8 +40,9 @@ export async function main() {
 
       for (const post of res.rows) {
         const { hash, timestamp } = post;
-        logger.debug('Replaying post', { hash, timestamp });
+        logger.debug('Publishing post...', { hash, timestamp });
         await publisher.publish(post);
+        logger.info('Post published', { hash, timestamp });
       }
     }
 


### PR DESCRIPTION
Lowered because replaying from testnet triggers Telegram 429 errors.

Also improved logging and corrected generic type definitions.