### PR TITLE
fix(frontend-main): display embedded images in post detail screen

### DIFF
--- a/packages/frontend-main/src/components/posts/PostContent.vue
+++ b/packages/frontend-main/src/components/posts/PostContent.vue
@@ -50,7 +50,7 @@ const youtubeLink = computed(() => {
           {{ $t('components.Button.hideImage') }}
         </Button>
         <div class="flex flex-col">
-          <img alt="embedded content" class="rounded" :src="imageUrl">
+          <img alt="embedded content" class="rounded" :src="imageUrl" referrerpolicy="no-referrer">
         </div>
       </template>
     </div>

--- a/packages/frontend-main/src/views/PostView.vue
+++ b/packages/frontend-main/src/views/PostView.vue
@@ -6,7 +6,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { toast } from 'vue-sonner';
 
 import PostActions from '@/components/posts/PostActions.vue';
-import PostMessage from '@/components/posts/PostMessage.vue';
+import PostContent from '@/components/posts/PostContent.vue';
 import PostMoreActions from '@/components/posts/PostMoreActions.vue';
 import PostsList from '@/components/posts/PostsList.vue';
 import PrettyTimestamp from '@/components/posts/PrettyTimestamp.vue';
@@ -88,7 +88,7 @@ async function handleReply() {
         </RouterLink>
         <PostMoreActions :post="post" />
       </div>
-      <PostMessage :message="post.message" class="mt-2" />
+      <PostContent :message="post.message" class="mt-2" />
       <PrettyTimestamp :timestamp="new Date(post.timestamp)" is-full-date class="self-start mt-4" />
 
       <div class="pr-2">


### PR DESCRIPTION
Embedded images weren't rendering in post detail view. Fixed by using the same content rendering component as explorer/feed screens.