### PR TITLE
refactor(frontend): introduce promoted posts & safer "burn" mechanism

### DIFF
--- a/packages/frontend-main/.env.example
+++ b/packages/frontend-main/.env.example
@@ -1,5 +1,8 @@
 VITE_ENVIRONMENT_TYPE=testnet
 
+VITE_DEFAULT_SEND_AMOUNT_ATOMICS=1
+VITE_PROMOTION_SEND_AMOUNT_ATOMICS=100000
+
 VITE_API_ROOT_DEVNET=https://dither-staging.stuyk.com/v1
 VITE_EXPLORER_URL_DEVNET=https://testnet.explorer.allinbits.services/atomone-devnet-1/tx
 VITE_COMMUNITY_WALLET_DEVNET=atone1uq6zjslvsa29cy6uu75y8txnl52mw06j6fzlep

--- a/packages/frontend-main/src/components/popups/FlagPostDialog.vue
+++ b/packages/frontend-main/src/components/popups/FlagPostDialog.vue
@@ -1,17 +1,15 @@
 <script lang="ts" setup>
 import type { Post } from 'api-main/types/feed';
 
-import { Decimal } from '@cosmjs/math';
 import { computed, ref } from 'vue';
 import { toast } from 'vue-sonner';
 
+import PromoteToggle from '@/components/posts/PromoteToggle.vue';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogTitle, ResponsiveDialogContent } from '@/components/ui/dialog';
-import InputPhoton from '@/components/ui/input/InputPhoton.vue';
 import { useFlagPost } from '@/composables/useFlagPost';
 import { useTxDialog } from '@/composables/useTxDialog';
 import { useConfigStore } from '@/stores/useConfigStore';
-import { fractionalDigits } from '@/utility/atomics';
 import { showBroadcastingToast } from '@/utility/toast';
 
 import PostMessage from '../posts/PostMessage.vue';
@@ -19,24 +17,25 @@ import PrettyTimestamp from '../posts/PrettyTimestamp.vue';
 import UserAvatar from '../users/UserAvatar.vue';
 import Username from '../users/Username.vue';
 
-const isBalanceInputValid = ref(false);
 const { flagPost, txError, txSuccess } = useFlagPost();
 const {
   isShown,
-  inputPhotonModel,
   popupState: flag,
   handleClose,
 } = useTxDialog<Post>('flag', txSuccess, txError);
 const configStore = useConfigStore();
-const amountAtomics = computed(() => configStore.config.defaultAmountEnabled ? configStore.config.defaultAmountAtomics : Decimal.fromUserInput(inputPhotonModel.value.toString(), fractionalDigits).atomics);
+const amountAtomics = computed(() => {
+  if (configStore.config.defaultAmountEnabled) {
+    return configStore.config.defaultAmountAtomics;
+  }
 
-const canSubmit = computed(() => {
-  return isBalanceInputValid.value;
+  return configStore.config.regularSendAmountAtomics;
 });
 
-function handleInputValidity(value: boolean) {
-  isBalanceInputValid.value = value;
-}
+// TODO: Verify wallet has enough balance for amountAtomics before allowing submit
+const canSubmit = computed(() => {
+  return true;
+});
 
 async function handleSubmit() {
   if (!canSubmit.value || !flag.value) {
@@ -73,8 +72,8 @@ async function handleSubmit() {
 
       <!-- Transaction Form -->
       <div class="flex flex-col w-full gap-4">
-        <InputPhoton v-if="!configStore.config.defaultAmountEnabled" v-model="inputPhotonModel" @on-validity-change="handleInputValidity" />
-        <Button class="w-full" :disabled="!isBalanceInputValid" @click="handleSubmit">
+        <PromoteToggle :show-promote-button="false" />
+        <Button class="w-full" :disabled="!canSubmit" @click="handleSubmit">
           {{ $t('components.Button.submit') }}
         </Button>
       </div>

--- a/packages/frontend-main/src/components/popups/TipUserDialog.vue
+++ b/packages/frontend-main/src/components/popups/TipUserDialog.vue
@@ -1,39 +1,37 @@
 <script lang="ts" setup>
-import { Decimal } from '@cosmjs/math';
 import { computed, ref } from 'vue';
 import { toast } from 'vue-sonner';
 
+import PromoteToggle from '@/components/posts/PromoteToggle.vue';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogTitle, ResponsiveDialogContent } from '@/components/ui/dialog';
-import InputPhoton from '@/components/ui/input/InputPhoton.vue';
 import { useTipUser } from '@/composables/useTipUser';
 import { useTxDialog } from '@/composables/useTxDialog';
 import { useConfigStore } from '@/stores/useConfigStore';
-import { fractionalDigits } from '@/utility/atomics';
 import { showBroadcastingToast } from '@/utility/toast';
 
 import DialogDescription from '../ui/dialog/DialogDescription.vue';
 import UserAvatarUsername from '../users/UserAvatarUsername.vue';
 
-const isBalanceInputValid = ref(false);
-
 const { tipUser, txError, txSuccess } = useTipUser();
 const {
   isShown,
-  inputPhotonModel,
   popupState: tip,
   handleClose,
 } = useTxDialog<string>('tipUser', txSuccess, txError);
 const configStore = useConfigStore();
-const amountAtomics = computed(() => configStore.config.defaultAmountEnabled ? configStore.config.defaultAmountAtomics : Decimal.fromUserInput(inputPhotonModel.value.toString(), fractionalDigits).atomics);
+const amountAtomics = computed(() => {
+  if (configStore.config.defaultAmountEnabled) {
+    return configStore.config.defaultAmountAtomics;
+  }
 
-const canSubmit = computed(() => {
-  return isBalanceInputValid.value;
+  return configStore.config.regularSendAmountAtomics;
 });
 
-function handleInputValidity(value: boolean) {
-  isBalanceInputValid.value = value;
-}
+// TODO: Verify wallet has enough balance for amountAtomics before allowing submit
+const canSubmit = computed(() => {
+  return true;
+});
 
 async function handleSubmit() {
   if (!canSubmit.value || !tip.value) {
@@ -62,8 +60,8 @@ async function handleSubmit() {
 
       <!-- Transaction Form -->
       <div class="flex flex-col w-full gap-4">
-        <InputPhoton v-if="!configStore.config.defaultAmountEnabled" v-model="inputPhotonModel" @on-validity-change="handleInputValidity" />
-        <Button class="w-full" :disabled="!isBalanceInputValid" @click="handleSubmit">
+        <PromoteToggle :show-promote-button="false" />
+        <Button class="w-full" :disabled="!canSubmit" @click="handleSubmit">
           {{ $t('components.Button.submit') }}
         </Button>
       </div>

--- a/packages/frontend-main/src/components/posts/PromoteToggle.vue
+++ b/packages/frontend-main/src/components/posts/PromoteToggle.vue
@@ -1,0 +1,125 @@
+<script lang="ts" setup>
+import { Decimal } from '@cosmjs/math';
+import { Info, Rocket } from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+import { Button } from '@/components/ui/button';
+import { ResponsivePopoverDialog } from '@/components/ui/popover';
+import Switch from '@/components/ui/switch/Switch.vue';
+import { useConfigStore } from '@/stores/useConfigStore';
+import { fractionalDigits } from '@/utility/atomics';
+
+defineProps<{
+  showPromoteButton?: boolean;
+}>();
+
+const isPromoted = defineModel<boolean>({ default: false });
+
+const isPopoverOpen = ref(false);
+const isLearnMoreOpen = ref(false);
+
+const configStore = useConfigStore();
+
+// Get send amounts from config
+const regularSendAtomics = computed(() => {
+  return configStore.config.defaultAmountEnabled
+    ? configStore.config.defaultAmountAtomics
+    : configStore.config.regularSendAmountAtomics;
+});
+
+const promotionSendAtomics = computed(() => configStore.config.promotionSendAmountAtomics);
+
+// Display values
+const regularSendDisplay = computed(() =>
+  Decimal.fromAtomics(regularSendAtomics.value, fractionalDigits).toString(),
+);
+
+const promotionSendDisplay = computed(() =>
+  Decimal.fromAtomics(promotionSendAtomics.value, fractionalDigits).toString(),
+);
+
+const currentAmountDisplay = computed(() => {
+  return isPromoted.value ? promotionSendDisplay.value : regularSendDisplay.value;
+});
+</script>
+
+<template>
+  <div class="flex flex-col w-full gap-2">
+    <!-- Send Amount Info -->
+    <div class="flex items-center justify-between w-full">
+      <div class="flex items-center gap-1 text-xs">
+        <span class="text-muted-foreground">
+          {{ $t('components.PromoteToggle.willSend') }}
+          <span class="font-semibold text-foreground">{{ currentAmountDisplay }} PHOTON</span>
+        </span>
+
+        <!-- Learn More Button -->
+        <ResponsivePopoverDialog v-model:open="isLearnMoreOpen" modal>
+          <template #trigger>
+            <Button
+              variant="ghost"
+              size="icon"
+              type="button"
+              class="h-4 w-4 p-0"
+              :title="$t('components.PromoteToggle.learnMore')"
+            >
+              <Info class="size-3 text-muted-foreground hover:text-foreground" />
+            </Button>
+          </template>
+          <div class="flex flex-col gap-2">
+            <h4 class="font-semibold">
+              {{ $t('components.PromoteToggle.sendExplainTitle') }}
+            </h4>
+            <p class="text-sm text-muted-foreground">
+              {{ $t('components.PromoteToggle.sendExplainDescription') }}
+            </p>
+          </div>
+        </ResponsivePopoverDialog>
+      </div>
+
+      <!-- Promote Button (bottom right) -->
+      <ResponsivePopoverDialog v-if="showPromoteButton" v-model:open="isPopoverOpen" modal>
+        <template #trigger>
+          <Button
+            variant="outline"
+            size="sm"
+            type="button"
+            class="gap-1.5 relative h-7 text-xs px-2"
+            :class="{ 'border-primary text-primary hover:bg-primary/5': isPromoted }"
+          >
+            <Rocket class="size-3.5" />
+            {{ $t('components.PromoteToggle.promoteButton') }}
+            <span
+              v-if="isPromoted"
+              class="absolute -top-1 -right-1 w-2 h-2 bg-primary rounded-full"
+            />
+          </Button>
+        </template>
+        <div class="flex flex-col gap-4">
+          <div class="flex items-start gap-3">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-primary/10 shrink-0">
+              <Rocket class="size-5 text-primary" />
+            </div>
+            <div class="flex flex-col gap-1 flex-1">
+              <h4 class="font-semibold">
+                {{ $t('components.PromoteToggle.popoverTitle') }}
+              </h4>
+              <p class="text-sm text-muted-foreground">
+                {{ $t('components.PromoteToggle.popoverDescription', { amount: promotionSendDisplay }) }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Toggle inside popover -->
+          <div class="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm font-medium">{{ $t('components.PromoteToggle.enablePromotion') }}</span>
+              <span class="text-xs text-muted-foreground">{{ promotionSendDisplay }} PHOTON</span>
+            </div>
+            <Switch id="promote-switch" v-model="isPromoted" />
+          </div>
+        </div>
+      </ResponsivePopoverDialog>
+    </div>
+  </div>
+</template>

--- a/packages/frontend-main/src/localization/index.ts
+++ b/packages/frontend-main/src/localization/index.ts
@@ -59,6 +59,21 @@ export const messages = {
         placeholder: 'Type amount',
         remaining: 'remaining',
       },
+      PromoteToggle: {
+        willSend: 'This will send',
+        learnMore: 'Learn more',
+        sendExplainTitle: 'Where does this PHOTON go?',
+        sendExplainDescription: 'PHOTON is sent to the community wallet to support the network and prioritize your content.',
+        promoteButton: 'Promote',
+        popoverTitle: 'Promote your post',
+        popoverDescription: 'Send {amount} PHOTON to boost your post and increase its visibility in the feed.',
+        regularAmount: 'Regular amount',
+        promotionBoost: 'Promotion boost',
+        total: 'Total',
+        enablePromotion: 'Enable Promotion',
+        promotionEnabled: 'Promotion enabled',
+        remove: 'Remove',
+      },
       PopupTitles: {
         likePost: 'Like Post',
         dislikePost: 'Dislike Post',
@@ -150,6 +165,7 @@ export const messages = {
       },
       PostActions: {
         replies: 'reply | replies',
+        promoted: 'Promoted',
       },
       PostEditorToolbar: {
         insertImageTitle: 'Insert Image URL',

--- a/packages/frontend-main/src/stores/useConfigStore.ts
+++ b/packages/frontend-main/src/stores/useConfigStore.ts
@@ -10,6 +10,8 @@ interface Config {
   envConfigs: typeof envConfigs;
   defaultAmountAtomics: string;
   defaultAmountEnabled: boolean;
+  regularSendAmountAtomics: string;
+  promotionSendAmountAtomics: string;
 }
 
 const defaultConfig: Config = {
@@ -17,6 +19,8 @@ const defaultConfig: Config = {
   selectedChain: import.meta.env.VITE_ENVIRONMENT_TYPE ?? 'mainnet',
   defaultAmountAtomics: Decimal.fromUserInput('0.1', fractionalDigits).atomics,
   defaultAmountEnabled: false,
+  regularSendAmountAtomics: import.meta.env.VITE_DEFAULT_SEND_AMOUNT_ATOMICS,
+  promotionSendAmountAtomics: import.meta.env.VITE_PROMOTION_SEND_AMOUNT_ATOMICS,
 };
 
 // deep clone the default config to avoid mutating the original object


### PR DESCRIPTION
Based on Jae's feedback , introduced the concept of "promoted posts" to replace the PHOTON input field.

 - Replaced the manual burn/send amount input with a promote toggle.
 - Users can no longer accidentally send arbitrary amounts, instead they choose between a standard or a promotion amount.
 - The promote amount is configurable via environment variables
 - Added a "promoted" badge for posts that meet the promotion threshold.

<img width="450" alt="SCR-20260113-renf" src="https://github.com/user-attachments/assets/79aa0a46-0b40-41ea-b813-8fc8b198dadd" />


Fixes #496 